### PR TITLE
Allow spoofing signingInfo for microG Companion/Services

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -4529,6 +4529,18 @@ public class PackageManagerService extends IPackageManager.Stub
 
             generateFakeSignature(p).ifPresent(fakeSignature -> {
                 packageInfo.signatures = new Signature[]{fakeSignature};
+                    try {
+                    packageInfo.signingInfo = new SigningInfo(
+                            new SigningDetails(
+                                    packageInfo.signatures,
+                                    SigningDetails.SignatureSchemeVersion.SIGNING_BLOCK_V3,
+                                    PackageParser.toSigningKeys(packageInfo.signatures),
+                                    null
+                            )
+                    );
+                } catch (CertificateException e) {
+                    Slog.e(TAG, "Caught an exception when creating signing keys: ", e);
+                }
             });
 
             return packageInfo;


### PR DESCRIPTION
- Spoof PackageInfo signingInfo + signatures so that G suite apps do not complain anymore.

Change-Id: I86f182c9e1d18b0e997803842577a90ef740cfd1